### PR TITLE
solucionado error en menu y preview del logo (Customization)

### DIFF
--- a/packages/customize/customize-frontend/src/pages/CustomConfigPage/CustomizationManagement/CustomizationLogo/CustomizationLogo.vue
+++ b/packages/customize/customize-frontend/src/pages/CustomConfigPage/CustomizationManagement/CustomizationLogo/CustomizationLogo.vue
@@ -91,7 +91,7 @@
 </template>
 <script>
 import LogoPreview from "../../../../components/LogoPreview"
-import {mapMutations} from 'vuex'
+import {mapMutations, mapState} from 'vuex'
 import {
   LOGO_MODE_ONLYTITLE,
   LOGO_MODE_RECTANGLE,
@@ -119,7 +119,17 @@ export default {
       },
     }
   },
+  mounted(){
+    this.formLogo.url = this.urlValue;
+    this.formLogo.mode = this.modeValue;
+    this.formLogo.title = this.titleValue;
+  },
   computed: {
+    ...mapState({
+      urlValue: state => state.customization.logo.url,
+      modeValue: (state) => state.customization.logo.mode,
+      titleValue: (state) => state.customization.logo.title
+    }),
     modes() {
       return [
         {id: LOGO_MODE_ROUND, name: this.$t('customization.logo.options.round')},

--- a/packages/customize/customize-frontend/src/pages/CustomConfigPage/CustomizationManagement/CustomizationMenu/CustomizationMenu.vue
+++ b/packages/customize/customize-frontend/src/pages/CustomConfigPage/CustomizationManagement/CustomizationMenu/CustomizationMenu.vue
@@ -9,6 +9,7 @@
                 <v-list-item
                         v-for="(item, i) in items"
                         :key="i"
+                        :disabled="i == value"
                 >
                     <v-list-item-icon>
                         <v-icon v-text="item.icon"></v-icon>


### PR DESCRIPTION
- La preview del logo se ve correctamente al actualizar el log.
- el menú ahora no desaparece al hacerle doble click en una opción.