### PR TITLE
ajuste tamaño toolbar y traduccion tiempo relativo

### DIFF
--- a/packages/common/common-frontend/src/components/Crud/CrudCreate/CrudCreate.vue
+++ b/packages/common/common-frontend/src/components/Crud/CrudCreate/CrudCreate.vue
@@ -6,13 +6,14 @@
           :title="title"
           :danger="toolbarError"
           @close="$emit('close')"
+          style="height:auto"
       />
 
       <v-card-text v-if="!!errorMessage">
         <error-alert :errorMessage="errorMessage"></error-alert>
       </v-card-text>
 
-      <v-card-text>
+      <v-card-text style="height:100%">
         <slot></slot>
       </v-card-text>
 

--- a/packages/notification/notification-frontend/src/components/NotificationButtonMiniShow/NotificationButtonMiniShow.vue
+++ b/packages/notification/notification-frontend/src/components/NotificationButtonMiniShow/NotificationButtonMiniShow.vue
@@ -101,15 +101,18 @@
 </template>
 
 <script>
-    import moment from "moment";
     import notificationProvider from "../../providers/notificationProvider";
+    import dayjs from 'dayjs';  
+    import relativeTime from 'dayjs/plugin/relativeTime';
+    import 'dayjs/locale/es'
+    import 'dayjs/locale/pt'
 
     export default {
         props: {
             notificationsItems: Array,
         },
         mounted() {
-            moment.locale(this.$t("notification.moment"));
+            this.$emit("updateNotifications");
         },
         methods: {
             changeStateRead(item) {
@@ -136,8 +139,13 @@
                     });
             },
             getRelativeDate(date) {
-                let currentDate = parseInt(date);
-                return moment(currentDate).fromNow();
+                dayjs.extend(relativeTime)
+                dayjs.locale(this.$t("notification.moment"))
+
+                let dateFormat = parseInt(date)
+                let currentDate = dayjs(dateFormat);
+                
+                return dayjs(currentDate).fromNow();
             },
             cleanContent(content){
                 let newArray = content.split(';;');


### PR DESCRIPTION
- Se agrega estilo a la toolbar y al form dentro de la misma para que mantenga el tamaño deseado, sin importar el tamaño del formulario
- Se utiliza dayjs y se modifica la logica del horario relativo en el miniShow de notificaciones