### PR TITLE
Fix to ticket #110694

### DIFF
--- a/packages/media/media-backend/src/DTOs/FileDTO.js
+++ b/packages/media/media-backend/src/DTOs/FileDTO.js
@@ -1,0 +1,31 @@
+export default class FileDTO {
+    constructor(file) {
+        this.filename = file.filename
+        this.description = file.description
+
+        this.tags = file.tags
+        this.mimetype = file.mimetype
+        this.encoding = file.encoding
+        this.extension = file.extension
+
+        this.type = file.type
+
+        this.relativePath = file.relativePath
+        this.absolutePath = file.absolutePath
+
+        this.size = file.size
+        this.url = file.url
+
+        this.lastAccess = file.lastAccess
+        this.createdAt = file.createdAt
+        this.createdBy = file.createdBy.username
+        this.expirationDate = file.expirationDate
+        
+        this.isPublic = file.isPublic
+        this.hits = file.hits
+        
+        this.groups = file.groups
+        this.users = file.users
+        this.fileReplaces = file.fileReplaces
+    }
+}


### PR DESCRIPTION
fix(media-backend): FileDTO created and used on fileRouter in order to easily avoid Sensitive Data Exposure vulnerability when getting uploaded files data at GET /file/:id endpoint